### PR TITLE
Further round trip fixes (profiles)

### DIFF
--- a/build/metaschema/lib/metaschema-check.sch
+++ b/build/metaschema/lib/metaschema-check.sch
@@ -92,9 +92,9 @@
             <sch:let name="decl" value="key('definition-by-name',@named,$composed-metaschema)"/>
             <sch:assert test="exists($decl)">No definition found for '<sch:value-of select="@named"/>' <sch:value-of select="local-name()"/></sch:assert>
             <sch:assert role="warning" test="empty($decl) or exists(self::m:field|self::m:assembly) or exists($decl/@group-as)">Reference is made to <sch:value-of select="local-name()"/> '<sch:value-of select="@named"/>', but their definition does not give a group name.</sch:assert>
-            <sch:assert test="empty($decl) or empty(@address) or ($decl/@address = @address)">The referenced definition has <sch:value-of select="if (exists($decl/@address)) then ('address ''' || $decl/@address || '''') else 'no address'"/></sch:assert>
-            <sch:assert test="exists($decl/@acquire-from) or empty(@address) or ($decl/m:flag/@name = @address)">The referenced definition has no flag named '<sch:value-of select="@address"/>'</sch:assert>
-            <sch:assert test="empty($decl/@acquire-from) or empty(@address) or not($decl/m:flag/@name = @address) or ($decl/m:flag[@name = current()/@address]/@required='yes')">The target definition has no required flag named <sch:value-of select="@address"/></sch:assert>
+            <sch:assert test="(empty($decl/@address) and empty(@address)) or ($decl/@address = @address)">The referenced definition has <sch:value-of select="if (exists($decl/@address)) then ('address ''' || $decl/@address || '''') else 'no address'"/></sch:assert>
+            <!--<sch:assert test="exists($decl/@acquire-from) or empty(@address) or ($decl/m:flag/@name = @address)">The referenced definition has no flag named '<sch:value-of select="@address"/>'</sch:assert>
+            <sch:assert test="empty($decl/@acquire-from) or empty(@address) or not($decl/m:flag/@name = @address) or ($decl/m:flag[@name = current()/@address]/@required='yes')">The target definition has no required flag named <sch:value-of select="@address"/></sch:assert>-->
             
             
             <sch:report test="@named = ../(* except current())/@named">Everything named the same must appear together</sch:report>

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -149,7 +149,7 @@
       <formal-name>Modify controls</formal-name>
       <description>Set parameters or amend controls in resolution</description>
       <model>
-         <assemblies named="set"/>
+         <assemblies named="set" address="param-id"/>
          <assemblies named="alter"/>
       </model>
    </define-assembly>
@@ -354,12 +354,12 @@
       <formal-name>Addition</formal-name>
       <description>Specifies contents to be added into controls or subcontrols, in resolution</description>
       <model>
-         <field named="title"/>
+         <field      named="title"/>
          <assemblies named="param" address="id"/>
-         <fields named="prop"/>
-         <fields named="link"/>
+         <fields     named="prop"/>
+         <fields     named="link"/>
          <assemblies named="part"/>
-         <assembly named="citation-list"/>
+         <assembly   named="citation-list"/>
       </model>
    </define-assembly>
    <define-flag datatype="NCName" name="control-id">


### PR DESCRIPTION
# Committer Notes

This PR corrects a small error in the profile metaschema with big downstream effects, namely that it breaks the XML to JSON conversion. When an object can be addressed by (labelled with) a flag, its container in the JSON becomes a map not an array; this happens only if its references in the metaschema have `@address` values corresponding to its definition. The Metaschema Schematron has  been modified to detect the error in future.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
