### PR TITLE
Implementation refactor plus sprint22 metaschema

### DIFF
--- a/build/metaschema/json/json-schema-metamap.xsl
+++ b/build/metaschema/json/json-schema-metamap.xsl
@@ -468,18 +468,8 @@
         <number key="minimum">0</number>
     </xsl:template>
     
-    <!-- Types are listed in ../xml/produce-xsd.xsl and ../xml/oscal-datatypes.xsd -->
-    
-    <xsl:variable name="numeric-types" as="element()*">
-        <type>decimal</type>
-        <type>float</type>
-        <type>double</type>
-    </xsl:variable>
-    
-    <xsl:template priority="2" match="*[@as-type=$numeric-types]" mode="object-type">
-        <string key="type">number</string>
-    </xsl:template>
-    
+    <!--Not supporting float and double--> 
+
     <xsl:template priority="2.1" match="*[@as-type = $datatypes/*/@key]" mode="object-type">
         <xsl:copy-of select="key('datatypes-by-name',@as-type,$datatypes)/*"/>
     </xsl:template>
@@ -488,6 +478,11 @@
         match="map" use="@key"/>
     
     <xsl:variable name="datatypes" expand-text="false">
+        <map key="decimal">
+            <string key="type">number</string>
+            <string key="pattern">(\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)</string>
+        </map>
+        
         <map key="date-with-timezone">
             <string key="type">string</string>
             <!--<string key="format">date</string>-->

--- a/build/metaschema/json/pull-datatypes.xsl
+++ b/build/metaschema/json/pull-datatypes.xsl
@@ -11,6 +11,8 @@
     <xsl:strip-space elements="*"/>
     
     <xsl:preserve-space elements="documentation"/>
+    
+    <!-- Utility XSLT -->
     <!-- converts XSD from ../xml/oscal-datatypes.xsd into JSON Schema notation-->
     
     <xsl:template match="schema">
@@ -68,4 +70,8 @@
     <xsl:template match="pattern">
         <string key="pattern">{ @value }</string>
     </xsl:template>
+    
+    <!--<xsl:template match="simpleType[@name=$known-types]" mode="cast-type">
+        <string key="pattern">((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))(Z|[+-][0-9]{2}:[0-9]{2})</string>
+    </xsl:template>-->
 </xsl:stylesheet>

--- a/build/metaschema/lib/metaschema-check.sch
+++ b/build/metaschema/lib/metaschema-check.sch
@@ -87,7 +87,7 @@
             <sch:assert test="empty(@ref) or exists($decl)" role="warning">No definition found for '<sch:value-of select="@ref"/>' <sch:value-of select="local-name()"/></sch:assert>
             <sch:assert test="empty(@ref) or empty($decl) or empty(@datatype) or (@datatype = $decl/@datatype)" role="warning">Flag data type doesn't match: the definition has '<sch:value-of select="$decl/@datatype"/>'</sch:assert>
             <sch:report test="@name=('RICHTEXT','STRVALUE','PROSE')">Flag should not be named "STRVALUE", "RICHTEXT" or "PROSE" (reserved names)</sch:report>
-            <sch:report test="@as-type != key('flags-by-name',@name)/@as-type,$composed-metaschema">Flag is declared with datatype '<sch:value-of select="@as-type"/>' while other flags with that name show datatype
+            <sch:report test="@as-type != key('flags-by-name',@name,$composed-metaschema)/@as-type">Flag is declared with datatype '<sch:value-of select="@as-type"/>' while other flags with that name show datatype
                 <sch:value-of select="string-join(((key('flags-by-name',@name) except .)/@as-type ! ('''' || . || '''')),', ')"/></sch:report>
         </sch:rule>
         

--- a/build/metaschema/lib/metaschema-docs-util.xsl
+++ b/build/metaschema/lib/metaschema-docs-util.xsl
@@ -91,17 +91,17 @@ function switch_view(who,flag) {
                 <!--<pre style="float:left">
                <xsl:value-of select="serialize($pruned-tree, $serialization-settings/* )"/>
             </pre>-->
-                <!--<pre>
+                <pre>
                <xsl:value-of select="serialize($surrogate-tree, $serialization-settings/* )"/>
-            </pre>-->
+            </pre>
                 
                 
                 <xsl:variable name="html-rendering">
                     <xsl:apply-templates mode="html-render" select="$surrogate-tree"/>
                 </xsl:variable>
-                <div class="OM-map" style="float:left; width:40%">
+                <!--<div class="OM-map" style="float:left; width:40%">
                     <xsl:copy-of select="$html-rendering"/>
-                </div>
+                </div>-->
                 <div class="OM-map" style="float:right; width:40%">
                     <xsl:apply-templates select="$html-rendering/*" mode="elaborate"/>
                 </div>

--- a/build/metaschema/lib/metaschema-jsondocs-jekyll-uswds.xsl
+++ b/build/metaschema/lib/metaschema-jsondocs-jekyll-uswds.xsl
@@ -112,9 +112,9 @@
       <xsl:variable name="alt-schema" select="replace($metaschema-code,'-json$','-xml')"/>
       <div style="float:right">
          <a href="/OSCAL/docs/schemas/{ $alt-schema }/#{ $alt-schema }_{ @name}">
-            <button class="button-xml-on">XML</button>
+            <button class="button-xml-on">Switch to XML</button>
          </a>
-         <button  class="button-json-off" disabled="disabled">JSON</button>
+         <!--<button  class="button-json-off" disabled="disabled">JSON</button>-->
       </div>
    </xsl:template>
 
@@ -339,7 +339,7 @@
       <li>
          <xsl:apply-templates mode="link-here" select="key('definitions',@ref)"/>
          <xsl:if test="empty(@ref)">
-            <xsl:apply-templates select="@name"/>
+            <a id="{../@name}-{@name}"><xsl:apply-templates select="@name"/></a><xsl:apply-templates select="@name"/>
          </xsl:if>
          <xsl:text> property </xsl:text>
          <xsl:apply-templates select="@as-type"/>

--- a/build/metaschema/lib/metaschema-jsonobject-map.xsl
+++ b/build/metaschema/lib/metaschema-jsonobject-map.xsl
@@ -22,7 +22,6 @@
    
    <!--<xsl:variable name="home" select="/"/>-->
    
-   
    <!--<xsl:template name="jekyll-template">
       <xsl:text>-\-\-&#xA;</xsl:text>
       <xsl:text>title: Schema map test&#xA;</xsl:text>

--- a/build/metaschema/lib/metaschema-xmldocs-jekyll-uswds.xsl
+++ b/build/metaschema/lib/metaschema-xmldocs-jekyll-uswds.xsl
@@ -123,9 +123,9 @@
    <xsl:template name="cross-links">
       <xsl:variable name="alt-schema" select="replace($metaschema-code,'-xml$','-json')"/>
       <div style="float:right">
-         <button disabled="disabled" class="button-xml-off">XML</button>
+         <!--<button disabled="disabled" class="button-xml-off">XML</button>-->
          <a href="/OSCAL/docs/schemas/{ $alt-schema }/#{ $alt-schema }_{ @name}">
-            <button class="button-json-on">JSON</button>
+            <button class="button-json-on">Switch to JSON</button>
          </a>
       </div>
    </xsl:template>
@@ -232,8 +232,7 @@
       <li>
          <xsl:apply-templates mode="link-here" select="key('definitions',@ref)"/>
          <xsl:if test="empty(@ref)">
-            <xsl:apply-templates select="@name"/>
-         </xsl:if>
+           <a id="{../@name}-{@name}"><xsl:apply-templates select="@name"/></a><xsl:apply-templates select="@name"/>
          <xsl:text> attribute </xsl:text>
          <xsl:apply-templates select="@required"/>
          <xsl:if test="empty(@required)"> (<i>optional</i>)</xsl:if>

--- a/build/metaschema/lib/metaschema.xsd
+++ b/build/metaschema/lib/metaschema.xsd
@@ -407,8 +407,9 @@
       <!-- TODO: Evaluate how to replace this DTD-based datatypes -->
       <xs:enumeration value="NMTOKENS" />
       <xs:enumeration value="decimal" />
-      <xs:enumeration value="float" />
-      <xs:enumeration value="double" />
+      <!-- Not supporting float or double -->
+      <!--<xs:enumeration value="float" />
+      <xs:enumeration value="double" />-->
       <xs:enumeration value="integer" />
       <xs:enumeration value="nonNegativeInteger"/>
       <xs:enumeration value="positiveInteger"/>

--- a/build/metaschema/unit-testing/datatypes/datatypes-prose_json-schema.json
+++ b/build/metaschema/unit-testing/datatypes/datatypes-prose_json-schema.json
@@ -37,17 +37,19 @@
             "title": "Plain text",
             "description": "plain text, no markup",
             "$id": "#/definitions/field-flag-plaintext",
+            "type": "object",
             "properties": {
                 "length": {
                     "title": "Length",
                     "description": "The length.",
                     "type": "integer",
-                    "minimum": 1
+                    "minimum": 1,
+                    "multipleOf": 1.0
                 },
-                "STRVALUE": {
-                   "type": "string"
-                }
-            }
+                "STRVALUE": {"type": "string"}
+            },
+            "required": ["STRVALUE"],
+            "additionalProperties": false
         },
         "field-richtext": {
             "title": "Rich text",
@@ -59,53 +61,43 @@
             "title": "Rich text",
             "description": "Rich text supports markup",
             "$id": "#/definitions/field-flag-richtext",
+            "type": "object",
             "properties": {
                 "length": {
                     "title": "Length",
                     "description": "The length.",
                     "type": "integer",
+                    "multipleOf": 1.0,
                     "minimum": 1
                 },
-                "RICHTEXT": {
-                   "type": "string"
-                }
-            }
+                "RICHTEXT": {"type": "string"}
+            },
+            "required": ["RICHTEXT"],
+            "additionalProperties": false
         },
         "field-prose": {
             "title": "Prose",
             "description": "Prose permits multiple paragraphs, lists, tables etc.",
             "$id": "#/definitions/field-prose",
-            "oneOf": [
-                {"type": "string"},
-                {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "minItems": 2
-                }
-            ]
+            "type": "string"
         },
         "field-flag-prose": {
             "title": "Prose",
             "description": "Prose permits multiple paragraphs, lists, tables etc.",
             "$id": "#/definitions/field-flag-prose",
+            "type" : "object",
             "properties": {
                 "length": {
                     "title": "Length",
                     "description": "The length.",
                     "type": "integer",
+                    "multipleOf": 1.0,
                     "minimum": 1
                 },
-                "PROSE": {
-                    "oneOf": [
-                        {"type": "string"},
-                        {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "minItems": 2
-                        }
-                    ]
-                }
-            }
+                "PROSE": {"type": "string"}                
+            },
+            "required": ["PROSE"],
+            "additionalProperties": false
         }
     },
     "properties": {

--- a/build/metaschema/unit-testing/datatypes/datatypes-prose_test-valid-PASS.json
+++ b/build/metaschema/unit-testing/datatypes/datatypes-prose_test-valid-PASS.json
@@ -1,8 +1,8 @@
 {
     "parent": {
-        "date": "2019-07-08TZ",
-        "plaintext": "Some *plain* text",
-        "richtext": "Some *rich* text",
-        "prose": [ "Here's some *extra prose*" ]
+        "field-date": "2019-07-08TZ",
+        "field-plaintext": "Some *plain* text",
+        "field-richtext": "Some *rich* text",
+        "field-prose": "Here's some *extra prose*"
     }
 }

--- a/build/metaschema/unit-testing/flag/flag-basic_json-schema.json
+++ b/build/metaschema/unit-testing/flag/flag-basic_json-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "http://csrc.nist.gov/ns/oscal/unit-testing/flag-basic-schema.json",
-    "$comment": "Metaschema Unit Test: flag: basic flag",
+    "$comment": "Metaschema Unit Test: flag: basic flag: JSON Schema",
     "type": "object",
     "definitions": {
         "parent": {

--- a/build/metaschema/unit-testing/flag/flag-basic_metaschema.xml
+++ b/build/metaschema/unit-testing/flag/flag-basic_metaschema.xml
@@ -8,7 +8,7 @@
  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
  xmlns:o="http://csrc.nist.gov/ns/oscal/example"
  root="parent">
-  <schema-name>Metaschema Unit Test: group-as</schema-name>
+  <schema-name>Metaschema Unit Test: flag: basic flag</schema-name>
   <schema-version>1.0-milestone1</schema-version>
   <short-name>metaschema-group-as</short-name>
   <namespace>http://csrc.nist.gov/ns/oscal/unit-testing/flag-basic</namespace>

--- a/build/metaschema/unit-testing/group-as/group-as-by-key_test_valid_PASS.json
+++ b/build/metaschema/unit-testing/group-as/group-as-by-key_test_valid_PASS.json
@@ -2,7 +2,7 @@
   "parent": {
     "props": {
       "id3": {"STRVALUE": "test3"},
-      "id3": {"STRVALUE": ""},
+      "id2": {"STRVALUE": ""},
       "id1": {"STRVALUE": "test1"}
     }
   }

--- a/build/metaschema/xml/produce-and-run-either-documentor.xsl
+++ b/build/metaschema/xml/produce-and-run-either-documentor.xsl
@@ -117,6 +117,7 @@
                 <xsl:call-template name="yaml-header">
                     <xsl:with-param name="tagname" select="string(@id)"/>
                     <xsl:with-param name="root"    select="starts-with(html:h5[1],(@id || ' is the root' ))"/>
+                    <xsl:with-param name="model-type" select="tokenize(@class,'\s+')[starts-with(.,'define-')] ! replace(.,'^define-','')"/>
                 </xsl:call-template>
                 <xsl:apply-templates select="." mode="cleanup"/>
             </xsl:result-document>
@@ -127,6 +128,7 @@
         <xsl:param name="tagname"  select="()"/>
         <xsl:param name="root"     as="xs:boolean" select="false()"/>
         <xsl:param name="overview" as="xs:boolean" select="false()"/>
+        <xsl:param name="model-type" as="xs:string"/>
         <xsl:text>---&#xA;</xsl:text>
         <xsl:text expand-text="true">title: Schema Documentation - { $metaschema-code }{ $tagname ! (' - ' || .) }&#xA;</xsl:text>
         <xsl:text expand-text="true">description: { $metaschema-code } schema documentation{ $tagname ! (' - ' || .) }&#xA;</xsl:text>
@@ -139,6 +141,7 @@
         <xsl:text expand-text="true">model: { $metaschema-code }-{ $target-format }&#xA;</xsl:text>
         <xsl:if test="$root">root: true&#xA;</xsl:if>
         <xsl:if test="$overview">overview: true&#xA;</xsl:if>
+        <xsl:if test="boolean($model-type)" expand-text="yes">model-type: { $model-type }</xsl:if>
         <xsl:text>---&#xA;</xsl:text>
     </xsl:template>
     

--- a/build/metaschema/xml/produce-xml-converter.xsl
+++ b/build/metaschema/xml/produce-xml-converter.xsl
@@ -205,9 +205,11 @@
 
                 <XSLT:apply-templates mode="as-string" select=".">
                     <XSLT:with-param name="key" select="$text-key"/>
-                    <!-- even an empty string must be written when the value key is dynamic
-                         since the key tells us the value for the (implicit) flag -->
-                    <XSLT:with-param name="mandatory" select="{ exists(json-value-key/@flag-name) }()"/>
+                    <!-- Always write the value key even when empty, as required by the JSON Schema -->
+                    <XSLT:with-param name="mandatory" select="true()"/>
+                    <!-- write an empty string when the value key is dynamic
+                         since the key tells us the value for the (implicit) flag:
+                         <XSLT:with-param name="mandatory" select="{ exists(json-value-key/@flag-name) }()"/> -->
                 </XSLT:apply-templates>
             </map>
         </XSLT:template>

--- a/build/metaschema/xml/produce-xsd.xsl
+++ b/build/metaschema/xml/produce-xsd.xsl
@@ -112,8 +112,9 @@
         <xs:simpleType name="NCName"/>
         <xs:simpleType name="NMTOKENS"/>
         <xs:simpleType name="decimal"/>
-        <xs:simpleType name="float"/>
-        <xs:simpleType name="double"/>
+        <!-- Not supporting float or double -->
+        <!--<xs:simpleType name="float"/>
+        <xs:simpleType name="double"/>-->
         <xs:simpleType name="integer"/>
         <xs:simpleType name="nonNegativeInteger"/>
         <xs:simpleType name="positiveInteger"/>

--- a/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
+++ b/src/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- XML produced by extraction/mapping from NVD XML :2018-11-02T16:55:46.916-04:00 -->
-<!-- Then modified by hand (2018-12-10, 2019-05-16, 2019-05-29) to add metadata, align with current schema, correct broken links -->
+<!-- XML produced by extraction/mapping from NVD XML 2018-11-02T16:55:46.916-04:00 -->
+<!-- Subsequently updated by hand (2018-12-10, 2019-05-16, 2019-05-29, 2019-08-17) -->
 <!-- Valid against the OSCAL catalog schema (project path /xml/schema/oscal-catalog-schema.xsd) -->
 <catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
-         id="uuid-926328ea-0ab8-4e41-8929-e162fa514e5c">
+   id="uuid-f3de8b2b-dc8e-4b17-9653-e83b708a6663">
    <metadata>
       <title>NIST Special Publication 800-53 Revision 4: Security and Privacy Controls for Federal Information Systems and Organizations</title>
       
-      <last-modified-date>2019-06-05T17:36:38.803-04:00</last-modified-date>
+      <last-modified-date>2019-08-17T11:39:39.05-04:00</last-modified-date>
       <version>2015-01-22</version>
       <oscal-version>1.0.0-milestone1</oscal-version>
       <prop name="keywords">Assurance, computer security, FISMA, Privacy Act, Risk Management Framework, security controls, security requirements</prop>
-      <link rel="alternate" href="#resource-pdf-sp-800-53r4"/>
-      <link rel="canonical" href="#resource-doi-sp-800-53r4"/>
+      <link rel="alternate" href="#resource-pdf-sp-800-53r4">NIST publication (PDF)</link>
+      <link rel="canonical" href="#resource-doi-sp-800-53r4">NIST publication via DOI lookup</link>
 
       <role id="creator">
          <title>Document creator</title>


### PR DESCRIPTION
# Committer Notes

Changes:

Fixed blocking bug in XML to JSON conversion. Formerly, text value fields were optional to allow omitting them from JSON when there is no value. Since they are now required, the fields are provided even when the value is an empty string. `<link href="some/link"/>` is an example: does the JSON provide a field for the value (`text`) or not? Now it does.

Also expanded the two empty links in the SP800-53 catalog so they would not show `text: ''`, by providing them reasonable values in the XML.
