### PR TITLE
Schema docs reconfiguration

### DIFF
--- a/build/metaschema/xml/produce-and-run-either-documentor.xsl
+++ b/build/metaschema/xml/produce-and-run-either-documentor.xsl
@@ -97,7 +97,8 @@
                 <xsl:with-param name="overview" select="true()"/>
             </xsl:call-template>
 
-            <xsl:apply-templates mode="cleanup" select="$html-docs/*/html:body/(* except child::html:div[contains-token(@class,'definition')])"/>
+            <!--<xsl:apply-templates mode="cleanup" select="$html-docs/*/html:body/(* except child::html:div[contains-token(@class,'definition')])"/>-->
+            <xsl:apply-templates mode="cleanup" select="$html-docs/*/html:body/*"/>
         </xsl:result-document>
 
         <xsl:result-document exclude-result-prefixes="#all" href="{$result-path}/../../maps/{ $metaschema-code }-{ $target-format }-map.html" method="html">
@@ -109,7 +110,7 @@
             </xsl:for-each>
         </xsl:result-document>
 
-        <xsl:for-each select="$html-docs/*/html:body/html:div[contains-token(@class,'definition')]">
+        <!--<xsl:for-each select="$html-docs/*/html:body/html:div[contains-token(@class,'definition')]">
             <xsl:result-document exclude-result-prefixes="#all" href="{$result-path}/{ $metaschema-code }_{@id}.html"
                method="html">
                 <xsl:message expand-text="yes">{$result-path}/{ $metaschema-code }_{@id}.html</xsl:message>
@@ -121,7 +122,7 @@
                 </xsl:call-template>
                 <xsl:apply-templates select="." mode="cleanup"/>
             </xsl:result-document>
-        </xsl:for-each>
+        </xsl:for-each>-->
     </xsl:template>
 
     <xsl:template name="yaml-header">

--- a/build/metaschema/xml/produce-and-run-either-documentor.xsl
+++ b/build/metaschema/xml/produce-and-run-either-documentor.xsl
@@ -21,6 +21,7 @@
                     <xsl:when test="/METASCHEMA/short-name='oscal-catalog'">https://github.com/usnistgov/OSCAL/blob/master/xml/schema/oscal_catalog_schema.xsd</xsl:when>
                     <xsl:when test="/METASCHEMA/short-name='oscal-profile'">https://github.com/usnistgov/OSCAL/blob/master/xml/schema/oscal_profile_schema.xsd</xsl:when>
                     <xsl:when test="/METASCHEMA/short-name='oscal-component'">https://github.com/usnistgov/OSCAL/blob/master/xml/schema/oscal_component_schema.xsd</xsl:when>
+                    <xsl:when test="/METASCHEMA/short-name='oscal-ssp'">https://github.com/usnistgov/OSCAL/blob/master/xml/schema/oscal_component_ssp.xsd</xsl:when>
                     <xsl:otherwise expand-text="true">NO XML SCHEMA PATH GIVEN FOR SCHEMA { /METASCHEMA/short-name }</xsl:otherwise>
                 </xsl:choose>
             </xsl:when>
@@ -28,7 +29,8 @@
                 <xsl:choose>
                     <xsl:when test="/METASCHEMA/short-name='oscal-catalog'">https://github.com/usnistgov/OSCAL/blob/master/json/schema/oscal_catalog_schema.json</xsl:when>
                     <xsl:when test="/METASCHEMA/short-name='oscal-profile'">https://github.com/usnistgov/OSCAL/blob/master/json/schema/oscal_profile_schema.json</xsl:when>
-                    <xsl:when test="/METASCHEMA/short-name='oscal-component'">https://github.com/usnistgov/OSCAL/blob/master/xml/schema/oscal_component_schema.json</xsl:when>
+                    <xsl:when test="/METASCHEMA/short-name='oscal-component'">https://github.com/usnistgov/OSCAL/blob/master/json/schema/oscal_component_schema.json</xsl:when>
+                    <xsl:when test="/METASCHEMA/short-name='oscal-ssp'">https://github.com/usnistgov/OSCAL/blob/master/json/schema/oscal_ssp_schema.json</xsl:when>
                     <xsl:otherwise expand-text="true">NO XML SCHEMA PATH GIVEN FOR SCHEMA { /METASCHEMA/short-name }</xsl:otherwise>
                 </xsl:choose>
             </xsl:when>

--- a/build/metaschema/xml/produce-and-run-either-documentor.xsl
+++ b/build/metaschema/xml/produce-and-run-either-documentor.xsl
@@ -12,9 +12,9 @@
     <!-- for development -->
     <!--<xsl:param name="target-format" select="()"/>-->
     <xsl:param name="target-format" as="xs:string">xml</xsl:param>
-    <xsl:param name="output-path"   as="xs:string">../../../docs/content/documentation/schemas</xsl:param>
+    <xsl:param name="output-path"   as="xs:string">../../../docs/layouts/partials/generated</xsl:param>
     <xsl:param name="schema-path">
-    <!-- TODO: confirm this value is passed from the calling script, then this can be ripped this out -->
+    <!-- TODO: confirm this value is passed from the calling script, then this can be ripped out -->
         <xsl:choose>
             <xsl:when test="$target-format = 'xml'">
                 <xsl:choose>
@@ -43,8 +43,6 @@
 
     <xsl:param name="example-converter-xslt-path" as="xs:string" required="yes"/>
     <!--"C:\Users\wap1\Documents\OSCAL\docs_jekyll_uswds\content\documentation\schemas\oscal-catalog\catalog.md"-->
-
-    <xsl:variable name="result-path" select="($output-path || '/_' || $metaschema-code || '-' || $target-format)"/>
 
     <!-- This template produces an XSLT dynamically by running an XSLT with a parameter set. -->
     <xsl:variable name="xslt">
@@ -91,8 +89,12 @@
     </xsl:variable>
 
     <xsl:template match="/">
-        <xsl:result-document exclude-result-prefixes="#all" href="{$result-path}/{ $metaschema-code }.html" method="html">
-            <xsl:message expand-text="yes">writing to {$result-path}/{ $metaschema-code }.html</xsl:message>
+        <!--file:/C:/Users/wap1/Documents/usnistgov/OSCAL/docs/layouts/partials/generated/xml-schema-oscal-catalog.html-->
+        <xsl:variable name="schema-docs-file" as="xs:string" expand-text="true">{$output-path}/{$target-format}-schema-{$metaschema-code}.html</xsl:variable>
+        <xsl:variable name="schema-map-file"  as="xs:string" expand-text="true">{$output-path}/{$target-format}-map-{$metaschema-code}.html</xsl:variable>
+        
+        <xsl:result-document exclude-result-prefixes="#all" href="{$schema-docs-file}" method="html">
+            <xsl:message expand-text="yes">writing to {$schema-docs-file}</xsl:message>
             <xsl:call-template name="yaml-header">
                 <xsl:with-param name="overview" select="true()"/>
             </xsl:call-template>
@@ -101,8 +103,8 @@
             <xsl:apply-templates mode="cleanup" select="$html-docs/*/html:body/*"/>
         </xsl:result-document>
 
-        <xsl:result-document exclude-result-prefixes="#all" href="{$result-path}/../../maps/{ $metaschema-code }-{ $target-format }-map.html" method="html">
-            <xsl:message expand-text="yes">{$result-path}/../../maps/{ $metaschema-code }-map.html</xsl:message>
+        <xsl:result-document exclude-result-prefixes="#all" href="{$schema-map-file}" method="html">
+            <xsl:message expand-text="yes">writing to {$schema-map-file}</xsl:message>
             <xsl:call-template name="map-header"/>
 
             <xsl:for-each select="$schema-map">


### PR DESCRIPTION
# Committer Notes

Rewired file production in schema docs generation:

1. Main schema docs are no longer split, but appear in a single file
1. Schema docs and maps are all written to `/docs/layouts/partials/generated`
1. Added setting for SSP schema locations when not provided at runtime