### PR TITLE
Woops, quickfix md-lint-checker issue, backport metaschema version.

### DIFF
--- a/.github/workflows/workflow-validate-repo-markdown.yml
+++ b/.github/workflows/workflow-validate-repo-markdown.yml
@@ -1,11 +1,11 @@
-name: Validate Repo Markdown
+name: Metaschema Validate Repo Markdown
 on:
   workflow_call:
     inputs:
       ignorePattern:
         description: 'a pattern provided to grep for files/directories to ignore'
         required: false
-        default: '^docs/'
+        default: '^website/'
         type: string
       markdownLinkCheckConfig:
         description: 'the path to the markdown link check config file'
@@ -13,10 +13,6 @@ on:
         default: 'build/config/.markdown-link-check/config.json'
         type: string
   workflow_dispatch:
-    branches:
-    - main
-    - develop
-    - "release-*"
     inputs:
       ignorePattern:
         description: 'a pattern provided to grep for files/directories to ignore'
@@ -34,14 +30,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # use this for pulls where checkout is anonymous
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3 # current: dcd71f646680f2efd8db4afa5ad64fdcba30e748
       with:
         submodules: recursive
     # Setup runtime environment
     # -------------------------
-    - name: Get markdown-link-check
+    - name: Set up NodeJS
+      uses: actions/setup-node@v3 # current: 56337c425554a6be30cdef71bf441f15be286854 
+      with:
+        node-version-file: 'build/.nvmrc'
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
+    - name: Setup Dependencies
       run: |
-          sudo npm install -g markdown-link-check
+        # NodeJS
+        cd "${{ github.workspace }}/build"
+        npm install --loglevel verbose
+        echo "$PWD/node_modules/.bin/" >> $GITHUB_PATH
     # Build Artifacts
     # ---------------
     - name: Validate repo Markdown content instances

--- a/.github/workflows/workflow-validate-repo-markdown.yml
+++ b/.github/workflows/workflow-validate-repo-markdown.yml
@@ -5,7 +5,7 @@ on:
       ignorePattern:
         description: 'a pattern provided to grep for files/directories to ignore'
         required: false
-        default: '^website/'
+        default: '^docs/'
         type: string
       markdownLinkCheckConfig:
         description: 'the path to the markdown link check config file'


### PR DESCRIPTION
# Committer Notes

Per Gitter conversation, resolve issues [with GitHub failed CI run](https://github.com/usnistgov/OSCAL/runs/6288809620?check_suite_focus=true) for usnistgov/OSCAL#1226.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- ~Have you added an explanation of what your changes do and why you'd like us to include them?~
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.~
