### PR TITLE
Responding to #1066: metaschema edits; CSS enhancement

### DIFF
--- a/src/metaschema/metaschema-author.css
+++ b/src/metaschema/metaschema-author.css
@@ -1,4 +1,4 @@
-METASCHEMA { font-family: Georgia, serif }
+METASCHEMA { font-family: Calibri, Verdana, sans-serif }
 
 * { display: block }
 
@@ -9,6 +9,11 @@ tag { color: black; font-family: monospace; font-size: 80%; font-weight: bold }
 METASCHEMA { }
 
 title { }
+
+import:before      
+ { content: 'import module ' oxy_urlChooser(edit, '@href', columns 60) }
+ 
+
 
 define-assembly,
 define-field,
@@ -23,6 +28,15 @@ define-flag:before
  oxy_textfield(edit, '@name', columns, 12) 
     }
 
+root-name:before { content: "Root name: "  }
+
+
+prop:before      
+ { content: 'property '
+ oxy_textfield(edit, '@name', columns, 25)
+ oxy_textfield(edit, '@value', columns, 30) 
+    }
+
 
 define-assembly[group-as]:before,
 define-field[group-as]:before,
@@ -35,12 +49,6 @@ define-field    *,
 define-flag     *  { margin: 0em }
 
 define-assembly > * { margin-top: 1em }
-
-allowed-values:before { content: "Allowed values" }
-allowed-values { border: thin solid black; padding: 1em }
-
-enum:before  { display: list-item }
-enum:before  { content: "enum" }
 
 pre { padding: 0.5em; background-color: gainsboro }
 
@@ -79,6 +87,8 @@ example *:after { content: '</' oxy_name() '>'; font-family: monospace; font-siz
 
 model { padding-left: 0.5em; border-left: medium solid blue; font-size: 80%; padding-right: 2em }
 
+model model { font-size: 100%; }
+
 flag:before { content:
  oxy_name()
   ' ref: ' oxy_textfield(edit, '@ref', columns, 12) 
@@ -105,10 +115,45 @@ prose:before { font-weight: bold; content:
 
 choice > * { margin-left: 2em }
 
-enum { display: block; font-size: 90%; padding-left: 1em }
-enum:before { content:  oxy_textfield(edit, '@value', columns, 24); }
-
 a { display: inline; color: blue }
 a:before { content: oxy_urlChooser(        
         edit, "@href",
         columns 42); }
+
+
+/* CONSTRAINTS */
+
+constraint > * { border: thin solid black; padding: 0.6em }
+
+allowed-values:before { content: "Allowed values"
+  ' level: '  oxy_combobox(edit, '@level', editable, false, values, "ERROR, WARNING" ) }
+
+enum { margin-left: 2em; display: list-item;
+       font-size: 90%; padding-left: 1em }
+enum:before { content: oxy_textfield(edit, '@value', columns, 24); }
+
+index { }
+index:before {  content: "Index: "
+  ' name: ' oxy_textfield(edit, '@name', columns, 24)
+  ' target: ' oxy_textfield(edit, '@target', columns, 52)
+  ' level: '  oxy_combobox(edit, '@level', editable, false, values, "ERROR, WARNING" ); }
+
+key-field { margin-left: 2em }
+key-field:before {  content: "Key field "
+  ' target: ' oxy_textfield(edit, '@target', columns, 52)
+  ' level: '  oxy_combobox(edit, '@level', editable, false, values, "ERROR, WARNING" ); }
+
+expect { }
+expect:before  {  content: "Expect "
+  ' target: ' oxy_textfield(edit, '@target', columns, 52)
+  ' test: '   oxy_textfield(edit, '@test', columns, 36)
+  ' level: '  oxy_combobox(edit, '@level', editable, false, values, "ERROR, WARNING" ); }
+
+index-has-key { }
+
+index-has-key:before { content: "Index has key: "
+  ' name: ' oxy_textfield(edit, '@name', columns, 24)
+  ' target: ' oxy_textfield(edit, '@target', columns, 52)
+  ' level: '  oxy_combobox(edit, '@level', editable, false, values, "ERROR, WARNING" ); }
+
+

--- a/src/metaschema/oscal_catalog_metaschema.xml
+++ b/src/metaschema/oscal_catalog_metaschema.xml
@@ -5,9 +5,8 @@
 <!DOCTYPE METASCHEMA [
    <!ENTITY allowed-values-control-group-property-name SYSTEM "shared-constraints/allowed-values-control-group-property-name.ent">
 ]>
-<METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:meta="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
-      xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
+<?xml-stylesheet type="text/css" href="metaschema-author.css"?>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
       <schema-name>OSCAL Control Catalog Model</schema-name>
       <schema-version>1.0.4</schema-version>
       <short-name>oscal-catalog</short-name>
@@ -93,10 +92,10 @@
             <formal-name>Control Group</formal-name>
             <description>A group of controls, or of groups of controls.</description>
             <define-flag name="id" as-type="token">
-                  <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
+                  <!-- This is an id because the identifier is assigned and managed externally by humans. -->
                   <formal-name>Group Identifier</formal-name>
                   <!-- Identifier Declaration -->
-                  <description>Identifies the group for the purpose of cross-linking within the defining instance or other instances that reference the catalog.</description>
+                  <description>Identifies the group for the purpose of cross-linking within the defining instance or from other instances that reference the catalog.</description>
                   <prop name="value-type" value="identifier"/>
                   <prop name="identifier-type" value="human-oriented"/>
                   <prop name="identifier-uniqueness" value="instance"/>
@@ -163,12 +162,16 @@
       </define-assembly>
       <define-assembly name="control">
             <formal-name>Control</formal-name>
-            <description>A <a href="https://pages.nist.gov/OSCAL/concepts/terminology/#control">structured object</a> representing a requirement or guideline, which when implemented will reduce an aspect of risk related to an information system and its information. Each security or privacy control within the catalog is defined by a distinct control instance.</description>
+            <description>A <a href="https://pages.nist.gov/OSCAL/concepts/terminology/#control"
+                        >structured object</a> representing a requirement or guideline, which when
+                  implemented will reduce an aspect of risk related to an information system and its
+                  information.</description>
             <define-flag name="id" as-type="token" required="yes">
                   <!-- This is an id because the idenfier is managed externally. -->
                   <formal-name>Control Identifier</formal-name>
                   <!-- Identifier Declaration -->
-                  <description>Identifies a control such that it can be referenced in the defining catalog and other OSCAL instances (e.g., profiles).</description>
+                  <description>Identifies a control such that it can be referenced in the defining
+                        catalog and other OSCAL instances (e.g., profiles).</description>
                   <prop name="value-type" value="identifier"/>
                   <prop name="identifier-type" value="human-oriented"/>
                   <prop name="identifier-uniqueness" value="local"/>
@@ -177,16 +180,21 @@
             </define-flag>
             <define-flag name="class" as-type="token">
                   <formal-name>Control Class</formal-name>
-                  <description>A textual label that provides a sub-type or characterization of the control.</description>
+                  <description>A textual label that provides a sub-type or characterization of the
+                        control.</description>
                   <remarks>
-                        <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
-                        <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
+                        <p>A <code>class</code> can be used in validation rules to express extra
+                              constraints over named items of a specific <code>class</code>
+                              value.</p>
+                        <p>A <code>class</code> can also be used in an OSCAL profile as a means to
+                              target an alteration to control content.</p>
                   </remarks>
             </define-flag>
             <model>
                   <define-field name="title" as-type="markup-line" min-occurs="1">
                         <formal-name>Control Title</formal-name>
-                        <description>A name given to the control, which may be used by a tool for display and navigation.</description>
+                        <description>A name given to the control, which may be used by a tool for
+                              display and navigation.</description>
                   </define-field>
                   <assembly ref="parameter" max-occurs="unbounded">
                         <group-as name="params" in-json="ARRAY"/>
@@ -203,7 +211,8 @@
                   </assembly>
                   <define-assembly name="mapping">
                         <formal-name>Mapping</formal-name>
-                        <description>A mapping between the containing control and another resource.</description>
+                        <description>A mapping between the containing control and another
+                              resource.</description>
                         <define-flag name="uuid" as-type="uuid" required="yes">
                               <formal-name>Mapping Identifier</formal-name>
                               <description>The unique identifier for the mapping.</description>
@@ -224,70 +233,97 @@
                   <!-- <any/> -->
             </model>
             <constraint>
-                  <expect id="catalog-control-require-statement-when-not-withdrawn" target="." test="prop[@name='status']/@value=('withdrawn','Withdrawn') or part[@name='statement']" />
-                  <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-            &allowed-values-control-group-property-name;
-                        <enum value="status">The status of a <code>control</code>. For example, a value of 'withdrawn' can indicate that the <code>control</code> has been withdrawn and should no longer be used.</enum>
+                  <expect id="catalog-control-require-statement-when-not-withdrawn" target="."
+                        test="prop[@name='status']/@value=('withdrawn','Withdrawn') or part[@name='statement']"/>
+                  <allowed-values
+                        target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                        &allowed-values-control-group-property-name;
+                        <enum value="status">The status of a <code>control</code>. For example, a
+                              value of 'withdrawn' can indicate that the <code>control</code> has
+                              been withdrawn and should no longer be used.</enum>
                   </allowed-values>
-                  <allowed-values target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='status']/@value">
+                  <allowed-values
+                        target="prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='status']/@value">
                         <enum value="withdrawn">The control is no longer used.</enum>
-                        <enum value="Withdrawn" deprecated="1.0.0">**(deprecated)*** Use 'withdrawn' instead.</enum>
+                        <enum value="Withdrawn" deprecated="1.0.0">**(deprecated)*** Use 'withdrawn'
+                              instead.</enum>
                   </allowed-values>
                   <allowed-values target="link/@rel" allow-other="yes">
-                        <enum value="reference">The link cites an external resource related to this control.</enum>
-                        <enum value="related">The link identifies another control with bearing to this control.</enum>
-                        <enum value="required">The link identifies another control that must be present if this control is present.</enum>
-                        <enum value="incorporated-into">The link identifies other control content where this control content is now addressed.</enum>
-                        <enum value="moved-to">The containing control definition was moved to the referenced control.</enum>
+                        <enum value="reference">The link cites an external resource related to this
+                              control.</enum>
+                        <enum value="related">The link identifies another control with bearing to
+                              this control.</enum>
+                        <enum value="required">The link identifies another control that must be
+                              present if this control is present.</enum>
+                        <enum value="incorporated-into">The link identifies other control content
+                              where this control content is now addressed.</enum>
+                        <enum value="moved-to">The containing control definition was moved to the
+                              referenced control.</enum>
                   </allowed-values>
                   <!-- TODO: add expect constraint to check for controls that reference themselves -->
-                  <index-has-key name="catalog-controls" target="link[@rel=('related','required','incorporated-into','moved-to') and starts-with(@href,'#')]">
+                  <index-has-key name="catalog-controls"
+                        target="link[@rel=('related','required','incorporated-into','moved-to') and starts-with(@href,'#')]">
                         <key-field target="@href" pattern="#(.*)"/>
                   </index-has-key>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="overview">An introduction to a control or a group of controls.</enum>
+                  <allowed-values
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                        <enum value="overview">An introduction to a control or a group of
+                              controls.</enum>
                         <enum value="statement">A set of control implementation requirements.</enum>
-                        <enum value="guidance">Additional information to consider when selecting, implementing, assessing, and monitoring a control.</enum>
-                        <enum value="assessment" deprecated="1.0.1">**(deprecated)** Use 'assessment-method' instead.</enum>
-                        <enum value="assessment-method">The part describes a method-based assessment over a set of assessment objects.</enum>
+                        <enum value="guidance">Additional information to consider when selecting,
+                              implementing, assessing, and monitoring a control.</enum>
+                        <enum value="assessment" deprecated="1.0.1">**(deprecated)** Use
+                              'assessment-method' instead.</enum>
+                        <enum value="assessment-method">The part describes a method-based assessment
+                              over a set of assessment objects.</enum>
                   </allowed-values>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='statement']//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                  <allowed-values
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name='statement']//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
                         <enum value="item">An individual item within a control statement.</enum>
                         <remarks>
                               <p>Nested statement parts are "item" parts.</p>
                         </remarks>
                   </allowed-values>
-                  <allowed-values target=".//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="objective" deprecated="1.0.1">**(deprecated)** Use 'assessment-objective' instead.</enum>
-                        <enum value="assessment-objective">The part describes a set of assessment objectives.</enum>
+                  <allowed-values
+                        target=".//part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                        <enum value="objective" deprecated="1.0.1">**(deprecated)** Use
+                              'assessment-objective' instead.</enum>
+                        <enum value="assessment-objective">The part describes a set of assessment
+                              objectives.</enum>
                         <remarks>
                               <p>Objectives can be nested.</p>
                         </remarks>
                   </allowed-values>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
-                        <enum value="objects" deprecated="1.0.1">**(deprecated)** Use 'assessment-objects' instead.</enum>
-                        <enum value="assessment-objects">Provides a listing of assessment objects.</enum>
+                  <allowed-values
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                        <enum value="objects" deprecated="1.0.1">**(deprecated)** Use
+                              'assessment-objects' instead.</enum>
+                        <enum value="assessment-objects">Provides a listing of assessment
+                              objects.</enum>
                         <remarks>
                               <p>Assessment objects appear on assessment methods.</p>
                         </remarks>
                   </allowed-values>
-                  
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
+                  <allowed-values
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@name">
                         <enum value="method" deprecated="1.0.1">**(deprecated)** Use 'method' in the 'http://csrc.nist.gov/ns/rmf' namespace. The assessment method to use. This typically appears on parts with the name "assessment-method".</enum>
                   </allowed-values>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/rmf')]/@name">
-                        <enum value="method">The assessment method to use. This typically appears on parts with the name "assessment-method".</enum>
+                  <allowed-values
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace('http://csrc.nist.gov/ns/rmf')]/@name">
+                        <enum value="method">The assessment method to use. This typically appears on
+                              parts with the name "assessment-method".</enum>
                   </allowed-values>
                   <expect level="WARNING" target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]" test="prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']"/>
-                  <allowed-values target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']/@value">
+                  <allowed-values
+                        target="part[has-oscal-namespace('http://csrc.nist.gov/ns/oscal') and @name=('assessment','assessment-method')]/prop[has-oscal-namespace(('http://csrc.nist.gov/ns/oscal','http://csrc.nist.gov/ns/rmf')) and @name='method']/@value">
                         <enum value="INTERVIEW">The process of holding discussions with individuals or groups of individuals within an organization to once again, facilitate assessor understanding, achieve clarification, or obtain evidence.</enum>
                         <enum value="EXAMINE">The process of reviewing, inspecting, observing, studying, or analyzing one or more assessment objects (i.e., specifications, mechanisms, or activities).</enum>
                         <enum value="TEST">The process of exercising one or more assessment objects (i.e., activities or mechanisms) under specified conditions to compare actual with expected behavior.</enum>
                   </allowed-values>
             </constraint>
             <remarks>
-                  <p>Controls may be grouped using <code>group</code>, and controls may be partitioned using <code>part</code> or further enhanced (extended) using <code>control</code>.</p>
-                  <p>A control must have a part with the name "statement", which represents the textual narrative of the control. This "statement" part must occur only once, but may have nested parts to allow for multiple paragraphs or sections of text.</p>
+                  <p>Each security or privacy control within the catalog is defined by a distinct control instance. Controls may be as complex or as simple as a catalog defines them. They may be decomposed or further specified into child <code>control</code> objects, for example to represent control enhancements or specific breakouts of control functionality, to be maintained as discrete requirements. Controls may also contain structured parts (using <code>part</code>) and they may be grouped together in families or classes with <code>group</code>.</p>
+                  <p>Control structures in OSCAL will also exhibit regularities and rules that are not codified in OSCAL but in its applications or domains of application. For example, for catalogs describing controls as defined by NIST SP 800-53, a control must have a part with the name "statement", which represents the textual narrative of the control. This "statement" part must occur only once, but may have nested parts to allow for multiple paragraphs or sections of text. This organization supports addressability of this data content as long as, and only insofar as, it is consistently implemented across the control set. As given with these model definitions, constraints defined and assigned here can aid in ensuring this regularity; but other such constraints and other useful patterns of use remain to be discovered and described.</p>
             </remarks>
             <example>
                   <control xmlns="http://csrc.nist.gov/ns/oscal/1.0" id="x">

--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -31,22 +31,6 @@
                         <prop name="identifier-scope" value="cross-instance"/>
                         <prop name="identifier-persistence" value="per-subject"/>
                         <remarks>
-                                <p>A <a href="/concepts/identifier-use/#human-oriented"
-                                                >human-oriented</a>, <a
-                                                href="/concepts/identifier-use/#locally-unique"
-                                                >locally unique</a> identifier with <a
-                                                href="/concepts/identifier-use/#cross-instance"
-                                                >cross-instance</a> scope that can be used to
-                                        reference this defined part elsewhere in <a
-                                                href="/concepts/identifier-use/#scope">this or other
-                                                OSCAL instances</a>. When referenced from another
-                                        OSCAL instance, this identifier must be referenced in the
-                                        context of the containing resource (e.g., import-profile).
-                                        This id should be assigned <a
-                                                href="/concepts/identifier-use/#consistency"
-                                                >per-subject</a>, which means it should be
-                                        consistently used to identify the same subject across
-                                        revisions of the document.</p>
                                 <p>While a part is not required to have an id, it is often desirable for an identifier to be provided, which allows the part to be referenced elsewhere in OSCAL document instances. For this reason, it is RECOMMENDED to provide a part identifier.</p>
                         </remarks>
                 </define-flag>

--- a/src/metaschema/oscal_control-common_metaschema.xml
+++ b/src/metaschema/oscal_control-common_metaschema.xml
@@ -7,7 +7,7 @@
 ]>
 <?xml-stylesheet type="text/css" href="metaschema-author.css"?>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
+        xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" abstract="yes">
         <schema-name>OSCAL Control Catalog Format -- Common Models</schema-name>
         <schema-version>1.0.4</schema-version>
         <short-name>oscal-control-common</short-name>
@@ -24,13 +24,29 @@
                         <!-- This is an id because the idenfier is intended to be human-readable. -->
                         <formal-name>Part Identifier</formal-name>
                         <!-- Identifier Declaration -->
-                        <description>Provides locally unique means to identify a given control part.</description>
+                        <description>A unique identifier for the part.</description>
                         <prop name="value-type" value="identifier"/>
                         <prop name="identifier-type" value="human-oriented"/>
                         <prop name="identifier-uniqueness" value="instance"/>
                         <prop name="identifier-scope" value="cross-instance"/>
                         <prop name="identifier-persistence" value="per-subject"/>
                         <remarks>
+                                <p>A <a href="/concepts/identifier-use/#human-oriented"
+                                                >human-oriented</a>, <a
+                                                href="/concepts/identifier-use/#locally-unique"
+                                                >locally unique</a> identifier with <a
+                                                href="/concepts/identifier-use/#cross-instance"
+                                                >cross-instance</a> scope that can be used to
+                                        reference this defined part elsewhere in <a
+                                                href="/concepts/identifier-use/#scope">this or other
+                                                OSCAL instances</a>. When referenced from another
+                                        OSCAL instance, this identifier must be referenced in the
+                                        context of the containing resource (e.g., import-profile).
+                                        This id should be assigned <a
+                                                href="/concepts/identifier-use/#consistency"
+                                                >per-subject</a>, which means it should be
+                                        consistently used to identify the same subject across
+                                        revisions of the document.</p>
                                 <p>While a part is not required to have an id, it is often desirable for an identifier to be provided, which allows the part to be referenced elsewhere in OSCAL document instances. For this reason, it is RECOMMENDED to provide a part identifier.</p>
                         </remarks>
                 </define-flag>
@@ -48,9 +64,9 @@
                 </define-flag>
                 <define-flag name="class" as-type="token">
                         <formal-name>Part Class</formal-name>
-                        <description>An optional textual label that provides a sub-type or characterization of the part's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple parts of the same control with the same <code>name</code> and <code>ns</code>.
-                        </description>
+                        <description>An optional textual providing a sub-type or characterization of the part's <code>name</code>, or a category to which the part belongs.</description>
                         <remarks>
+                                <p>One use of this flag is to distinguish or discriminate between the semantics of multiple parts of the same control with the same <code>name</code> and <code>ns</code> (since even within a given namespace it can be useful to overload a name).</p>
                                 <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
                                 <p>A <code>class</code> can also be used in an OSCAL profile as a means to target an alteration to control content.</p>
                         </remarks>
@@ -92,7 +108,7 @@
                         <p>Tools that process OSCAL content are not required to interpret unrecognized OSCAL extensions; however, OSCAL compliant tools should not modify or remove unrecognized extensions, unless there is a compelling reason to do so, such as data sensitivity.</p>
                 </remarks>
                 <example>
-                        <description>Multiple Parts with Different Organization-Specific Names</description>
+                        <description>Multiple Parts with Different Organization-Specific Names.</description>
                         <part xmlns="http://csrc.nist.gov/ns/oscal/1.0" name="statement" id="statement-A">
                                 <part ns="http://fedramp.gov/ns/oscal" name="status" id="statement-A-FedRAMP">A requirement specific to FedRAMP stakeholders.</part>
                                 <part ns="https://defense.gov" name="status" id="statement-A-DoD">A requirement specific to the Department of Defense stakeholders.</part>
@@ -143,7 +159,8 @@
                         </define-field>
                         <define-field name="usage" as-type="markup-multiline" in-xml="WITH_WRAPPER">
                                 <formal-name>Parameter Usage Description</formal-name>
-                                <description>Describes the purpose and use of a parameter</description>
+                                <description>Describes the purpose and use of a
+                                        parameter.</description>
                         </define-field>
                         <assembly ref="parameter-constraint" max-occurs="unbounded">
                                 <use-name>constraint</use-name>
@@ -194,7 +211,7 @@
 
         <define-assembly name="parameter-constraint">
                 <formal-name>Constraint</formal-name>
-                <description>A formal or informal expression of a constraint or test</description>
+                <description>A formal or informal expression of a constraint or test.</description>
                 <model>
                         <define-field name="description" as-type="markup-multiline" in-xml="WITH_WRAPPER">
                                 <formal-name>Constraint Description</formal-name>
@@ -207,7 +224,8 @@
                                 <model>
                                         <define-field name="expression" as-type="string" min-occurs="1">
                                                 <formal-name>Constraint test</formal-name>
-                                                <description>A formal (executable) expression of a constraint</description>
+                                                <description>A formal (executable) expression of a
+                                                  constraint.</description>
                                         </define-field>
                                         <field ref="remarks" in-xml="WITH_WRAPPER"/>
                                 </model>
@@ -232,7 +250,7 @@
 
         <define-assembly name="parameter-selection">
                 <formal-name>Selection</formal-name>
-                <description>Presenting a choice among alternatives</description>
+                <description>Presenting a choice among alternatives.</description>
                 <define-flag name="how-many" as-type="token">
                         <formal-name>Parameter Cardinality</formal-name>
                         <description>Describes the number of selections that must occur. Without this setting, only one value should be assumed to be permitted.</description>
@@ -246,7 +264,8 @@
                 <model>
                         <define-field name="parameter-choice" as-type="markup-line" max-occurs="unbounded">
                                 <formal-name>Choice</formal-name>
-                                <description>A value selection among several such options</description>
+                                <description>A value selection among several such
+                                        options.</description>
                                 <use-name>choice</use-name>
                                 <json-value-key>value</json-value-key>
                                 <group-as name="choice" in-json="ARRAY"/>

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -2,8 +2,9 @@
 <?xml-model href="../../build/metaschema/toolchains/xslt-M4/validate/metaschema-composition-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <!-- OSCAL CATALOG METASCHEMA -->
 <!-- validate with XSD and Schematron (linked) -->
+<?xml-stylesheet type="text/css" href="metaschema-author.css"?>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd" abstract="yes">
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" abstract="yes">
     <schema-name>OSCAL Document Metadata Description</schema-name>
     <schema-version>1.0.4</schema-version>
     <short-name>oscal-metadata</short-name>
@@ -76,10 +77,9 @@
                 <description>Defines a function, which might be assigned to a party in a specific situation.</description>
                 <group-as name="roles" in-json="ARRAY"/>
                 <define-flag name="id" as-type="token" required="yes">
-                    <!-- This is an id because the idenfier is assigned and managed by humans. -->
                     <!-- Identifier Declarations -->
                     <formal-name>Role Identifier</formal-name>
-                    <description>Provides locally unique means to identify a given role.</description>
+                    <description>A unique identifier for the role.</description>
                     <prop name="value-type" value="identifier"/>
                     <prop name="identifier-type" value="human-oriented"/>
                     <prop name="identifier-uniqueness" value="instance"/>
@@ -162,7 +162,21 @@
                 <group-as name="locations" in-json="ARRAY"/>
                 <define-flag name="uuid" as-type="uuid" required="yes">
                     <formal-name>Location Universally Unique Identifier</formal-name>
-                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined location elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>location</code> can be used to reference the data item locally or globally (e.g., from an importing OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+                    <description>A unique ID for the location, for reference.</description>
+                    <remarks>
+                        <p>A <a href="/concepts/identifier-use/#machine-oriented"
+                                >machine-oriented</a>, <a
+                                href="/concepts/identifier-use/#globally-unique">globally unique</a>
+                            identifier with <a href="/concepts/identifier-use/#cross-instance"
+                                >cross-instance</a> scope that can be used to reference this defined
+                            location elsewhere in <a href="/concepts/identifier-use/#scope">this or
+                                other OSCAL instances</a>. The locally defined <em>UUID</em> of the
+                                <code>location</code> can be used to reference the data item locally
+                            or globally (e.g., from an importing OSCAL instance). This UUID should
+                            be assigned <a href="/concepts/identifier-use/#consistency"
+                                >per-subject</a>, which means it should be consistently used to
+                            identify the same subject across revisions of the document.</p>
+                    </remarks>
                 </define-flag>
                 <model>
                     <define-field name="title" as-type="markup-line">
@@ -231,8 +245,7 @@
                 <define-flag name="uuid" as-type="uuid" required="yes">
                     <formal-name>Party Universally Unique Identifier</formal-name>
                     <!-- Identifier Declaration -->
-                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined party elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. The locally defined <em>UUID</em> of the <code>party</code> can be used to reference the data item locally or globally (e.g., from an importing OSCAL instance). This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
-                    <description>Provides locally unique means to identify a given party.</description>
+                    <description>A unique identifier for the party.</description>
                     <prop name="value-type" value="identifier"/>
                     <prop name="identifier-type" value="machine-oriented"/>
                     <prop name="identifier-uniqueness" value="instance"/>
@@ -261,7 +274,9 @@
                     <define-field name="external-id" max-occurs="unbounded">
                         <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
                         <formal-name>Party External Identifier</formal-name>
-                        <description>An identifier for a person or organization using a designated scheme. e.g. an Open Researcher and Contributor ID (ORCID)</description>
+                        <description>An identifier for a person or organization using a designated
+                            scheme. e.g. an Open Researcher and Contributor ID
+                            (ORCID).</description>
                         <json-value-key>id</json-value-key>
                         <group-as name="external-ids" in-json="ARRAY"/>
                         <define-flag name="scheme" as-type="uri" required="yes">
@@ -306,8 +321,7 @@
                     <define-field name="member-of-organization" as-type="uuid" max-occurs="unbounded">
                         <formal-name>Organizational Affiliation</formal-name>
                         <!-- Identifier Reference -->
-                        <description>A reference to another <code>party</code> (<code>person</code> or <code>organization</code>) that this subject is associated with. The <em>UUID</em> of the <code>party</code> in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).
-                        </description>
+                        <description>A reference to another <code>party</code> by UUID, typically an organization, that this subject is associated with.</description>
                         <prop name="value-type" value="identifier-reference"/>
                         <prop name="identifier-type" value="machine-oriented"/>
                         <prop name="identifier-scope" value="cross-instance"/>
@@ -319,6 +333,14 @@
                             </index-has-key>
                         </constraint>
                         <remarks>
+                            <p>Since the reference target of an organizational affiliation must be
+                                another  <code>party</code> (whether further qualified as person or
+                                organization) as inidcated by its <code>uuid</code>. As a <a
+                                    href="/concepts/identifier-use/#machine-oriented"
+                                    >machine-oriented</a> identifier with uniqueness across document
+                                and trans-document scope, this <code>uuid</code> value is sufficient
+                                to reference the data item locally or globally across related
+                                documents, e.g., in an imported OSCAL instance. </p>
                             <p>Parties of both the <code>person</code> or <code>organization</code> type can be associated with an organization using the <code>member-of-organization</code>.</p>
                         </remarks>
                     </define-field>
@@ -429,8 +451,7 @@
     <define-flag name="location-uuid" as-type="uuid">
         <formal-name>Location Universally Unique Identifier Reference</formal-name>
         <!-- Identifier Reference -->
-        <description>A reference to a <code>location</code> defined in the <code>metadata</code> section of this or another OSCAL instance. The <em>UUID</em> of the <code>location</code> in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).
-        </description>
+        <description>Reference to a location by UUID.</description>
         <prop name="value-type" value="identifier-reference"/>
         <prop name="identifier-type" value="machine-oriented"/>
         <prop name="identifier-scope" value="cross-instance"/>
@@ -446,8 +467,7 @@
     <define-field name="location-uuid" as-type="uuid">
         <formal-name>Location Universally Unique Identifier Reference</formal-name>
         <!-- Identifier Reference -->
-        <description>A reference to a <code>location</code> defined in the <code>metadata</code> section of this or another OSCAL instance. The <em>UUID</em> of the <code>location</code> in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).
-        </description>
+        <description>Reference to a location by UUID.</description>
         <prop name="value-type" value="identifier-reference"/>
         <prop name="identifier-type" value="machine-oriented"/>
         <prop name="identifier-scope" value="cross-instance"/>
@@ -457,16 +477,12 @@
                 <key-field target="."/>
             </index-has-key>
         </constraint>
-        <remarks>
-            <p>See the <a href="/concepts/identifier-use/#scope">Concepts - Identifier Use</a> page for additional information about the referenced identifier's scope.</p>
-          </remarks>
     </define-field>
 
     <define-field name="party-uuid" as-type="uuid">
         <formal-name>Party Universally Unique Identifier Reference</formal-name>
         <!-- Identifier Reference -->
-        <description>A reference to another <code>party</code> defined in <code>metadata</code>. The <em>UUID</em> of the <code>party</code> in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).
-        </description>
+        <description>Reference to a party by UUID.</description>
         <prop name="value-type" value="identifier-reference"/>
         <prop name="identifier-type" value="machine-oriented"/>
         <prop name="identifier-scope" value="cross-instance"/>
@@ -476,15 +492,12 @@
                 <key-field target="."/>
             </index-has-key>
         </constraint>
-        <remarks>
-            <p>See the <a href="/concepts/identifier-use/#scope">Concepts - Identifier Use</a> page for additional information about the referenced identifier's scope.</p>
-          </remarks>
     </define-field>
 
     <define-field name="role-id" as-type="token">
         <formal-name>Role Identifier Reference</formal-name>
         <!-- Identifier Reference -->
-        <description>A reference to <code>roles</code> served by the user.</description>
+        <description>Reference to a role by UUID.</description>
         <prop name="value-type" value="identifier-reference"/>
         <prop name="identifier-type" value="human-oriented"/>
         <prop name="identifier-scope" value="cross-instance"/>
@@ -509,8 +522,21 @@
                 <group-as name="resources" in-json="ARRAY"/>
                 <define-flag name="uuid" as-type="uuid" required="yes">
                     <formal-name>Resource Universally Unique Identifier</formal-name>
+                    <description>A unique identifier for a resource, for referencing across document
+                        and trans-document scope.</description>
+                    <remarks>
+                        <p>A <a href="/concepts/identifier-use/#machine-oriented"
+                                >machine-oriented</a>, <a
+                                href="/concepts/identifier-use/#globally-unique">globally unique</a>
+                            identifier with <a href="/concepts/identifier-use/#cross-instance"
+                                >cross-instance</a> scope that can be used to reference this defined
+                            resource elsewhere in <a href="/concepts/identifier-use/#scope">this or
+                                other OSCAL instances</a>. This UUID should be assigned <a
+                                href="/concepts/identifier-use/#consistency">per-subject</a>, which
+                            means it should be consistently used to identify the same subject across
+                            revisions of the document.</p>
+                    </remarks>
                     <!-- identifier declaration -->
-                    <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined resource elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
                 </define-flag>
                 <model>
                     <define-field name="title" as-type="markup-line">
@@ -712,7 +738,19 @@
         <define-flag name="uuid" as-type="uuid">
             <formal-name>Property Universally Unique Identifier</formal-name>
             <!-- identifier declaration -->
-            <description>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that can be used to reference this defined property elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</description>
+            <description>A unique identifier for a property, for referencing across trans-document
+                scope.</description>
+            <remarks>
+                <p>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a
+                        href="/concepts/identifier-use/#globally-unique">globally unique</a>
+                    identifier with <a href="/concepts/identifier-use/#cross-instance"
+                        >cross-instance</a> scope that can be used to reference this defined
+                    property elsewhere in <a href="/concepts/identifier-use/#scope">this or other
+                        OSCAL instances</a>. This UUID should be assigned <a
+                        href="/concepts/identifier-use/#consistency">per-subject</a>, which means it
+                    should be consistently used to identify the same subject across revisions of the
+                    document.</p>
+            </remarks>
         </define-flag>
         <define-flag name="ns" as-type="uri" default="http://csrc.nist.gov/ns/oscal">
             <formal-name>Property Namespace</formal-name>
@@ -728,10 +766,16 @@
         </define-flag>
         <define-flag name="class" as-type="token">
             <formal-name>Property Class</formal-name>
-            <description>A textual label that provides a sub-type or characterization of the property's <code>name</code>. This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same <code>name</code> and <code>ns</code>.
-            </description>
+            <description>A textual label that provides a sub-type or characterization of the
+                property's <code>name</code>.</description>
             <remarks>
-                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value.</p>
+                <p>This can be used to further distinguish or discriminate between the semantics of
+                    multiple properties of the same object with the same <code>name</code> and
+                        <code>ns</code>, or to group properties into categories.</p>
+                <p>A <code>class</code> can be used in validation rules to express extra constraints
+                    over named items of a specific <code>class</code> value. It is available for
+                    grouping, but unlike <code>group</code> is not expected specifically to
+                    designate any group membership as such.</p>
             </remarks>
         </define-flag>
         <define-flag name="group" as-type="token">
@@ -925,9 +969,13 @@
 
     <define-flag name="media-type" as-type="string">
         <formal-name>Media Type</formal-name>
-        <description>A media type provides a label that indicates the nature of a resource. The Internet Assigned Numbers Authority (IANA) <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">Media Types Registry</a> defines a standardized set of media types, which may be used here.
-        </description>
+        <description>A label that indicates the nature of a resource, as a data serialization or
+            format.</description>
         <remarks>
+            <p> The Internet Assigned Numbers Authority (IANA) <a
+                    href="https://www.iana.org/assignments/media-types/media-types.xhtml">Media
+                    Types Registry</a> defines a standardized set of media types, which may be used
+                here.</p>
             <p>The <code>application/oscal+xml</code>, <code>application/oscal+json</code> or <code>application/oscal+yaml</code> media types SHOULD be used when referencing OSCAL XML, JSON, or YAML resources respectively.</p>
             <p>**Note: There is no official media type for YAML at this time.** OSCAL documents should specify <code>application/yaml</code> for general YAML content, or <code>application/oscal+yaml</code> for YAML-based OSCAL content. This approach aligns with use of a structured name suffix, per <a href="https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8">RFC 6838 Section 4.2.8</a>.</p>
             <p>Some earlier OSCAL content incorporated the model into the media type. For example: <code>application/oscal.catalog+xml</code>. This practice SHOULD be avoided, since the OSCAL model can be detected by parsing the initial content of the referenced resource.</p>
@@ -984,8 +1032,9 @@
 
     <define-field name="email-address" as-type="email" scope="local">
         <formal-name>Email Address</formal-name>
-        <description>An email address as defined by <a href="https://tools.ietf.org/html/rfc5322#section-3.4.1">RFC 5322 Section 3.4.1</a>.
-        </description>
+        <description>An email address as defined by <a
+                href="https://tools.ietf.org/html/rfc5322#section-3.4.1">RFC 5322 Section
+            3.4.1</a>.</description>
     </define-field>
 
     <define-field name="telephone-number" scope="local">
@@ -1029,11 +1078,12 @@
             </define-field>
             <define-field name="state">
                 <formal-name>State</formal-name>
-                <description>State, province or analogous geographical region for mailing address</description>
+                <description>State, province or analogous geographical region for a mailing
+                    address.</description>
             </define-field>
             <define-field name="postal-code">
                 <formal-name>Postal Code</formal-name>
-                <description>Postal or ZIP code for mailing address</description>
+                <description>Postal or ZIP code for mailing address.</description>
             </define-field>
             <define-field name="country">
                 <formal-name>Country Code</formal-name>
@@ -1064,11 +1114,14 @@
     <define-field name="document-id" scope="local">
         <formal-name>Document Identifier</formal-name>
         <!-- identifier declaration -->
-        <description>A document identifier qualified by an identifier <code>scheme</code>. A document identifier provides a <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with a <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that is used for a group of documents that are to be treated as different versions of the same document. If this element does not appear, the value of the "uuid" flag of the top-level root field can serve as a document identifier.</description>
+        <description>A document identifier qualified by an identifier
+            <code>scheme</code>.</description>
         <json-value-key>identifier</json-value-key>
         <define-flag name="scheme" as-type="uri">
             <formal-name>Document Identification Scheme</formal-name>
-            <description>Qualifies the kind of document identifier using a URI. If the scheme is not provided the value of the element will be interpreted as a string of characters. </description>
+            <description>Qualifies the kind of document identifier using a URI. If the scheme is not
+                provided the value of the element will be interpreted as a string of
+                characters.</description>
             <constraint>
                 <allowed-values allow-other="yes">
                     <enum value="http://www.doi.org/">A <a href="https://www.doi.org/hb.html">Digital Object Identifier</a> (DOI); use is preferred, since this allows for retrieval of a full bibliographic record.</enum>
@@ -1079,9 +1132,17 @@
             </remarks>
         </define-flag>
         <remarks>
+            <p>A document identifier provides a <a href="/concepts/identifier-use/#globally-unique"
+                    >globally unique</a> identifier with a <a
+                    href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that is
+                used for a group of documents that are to be treated as different versions,
+                representations or digital surrogates of the same document.</p>
             <p>A document identifier provides an additional data point for identifying a document that can be assigned by a publisher or organization for purposes in a wider system, such as a digital object identifier (DOI) or a local content management system identifier.</p>
             <p>Use of a document identifier allows for document creators to associate sets of documents that are related in some way by the same <code>document-id</code>.</p>
-            <p>An OSCAL document always has an implicit document identifier provided by the document's UUID, defined by the <code>uuid</code> on the top-level object. Having a default UUID-based identifier ensures all documents can be minimally identified when other document identifiers are not provided.</p>
+            <p>An OSCAL document always has an implicit document identifier provided by the
+                document's UUID, defined by the <code>uuid</code> on the top-level object. Having a
+                default UUID-based identifier ensures all documents can be minimally identified when
+                other document identifiers are not provided.</p>
         </remarks>
     </define-field>
 </METASCHEMA>

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -333,14 +333,7 @@
                             </index-has-key>
                         </constraint>
                         <remarks>
-                            <p>Since the reference target of an organizational affiliation must be
-                                another  <code>party</code> (whether further qualified as person or
-                                organization) as inidcated by its <code>uuid</code>. As a <a
-                                    href="/concepts/identifier-use/#machine-oriented"
-                                    >machine-oriented</a> identifier with uniqueness across document
-                                and trans-document scope, this <code>uuid</code> value is sufficient
-                                to reference the data item locally or globally across related
-                                documents, e.g., in an imported OSCAL instance. </p>
+                            <p>Since the reference target of an organizational affiliation must be another <code>party</code> (whether further qualified as person or organization) as inidcated by its <code>uuid</code>. As a <a href="/concepts/identifier-use/#machine-oriented" >machine-oriented</a> identifier with uniqueness across document and trans-document scope, this <code>uuid</code> value is sufficient to reference the data item locally or globally across related documents, e.g., in an imported OSCAL instance. </p>
                             <p>Parties of both the <code>person</code> or <code>organization</code> type can be associated with an organization using the <code>member-of-organization</code>.</p>
                         </remarks>
                     </define-field>
@@ -525,16 +518,7 @@
                     <description>A unique identifier for a resource, for referencing across document
                         and trans-document scope.</description>
                     <remarks>
-                        <p>A <a href="/concepts/identifier-use/#machine-oriented"
-                                >machine-oriented</a>, <a
-                                href="/concepts/identifier-use/#globally-unique">globally unique</a>
-                            identifier with <a href="/concepts/identifier-use/#cross-instance"
-                                >cross-instance</a> scope that can be used to reference this defined
-                            resource elsewhere in <a href="/concepts/identifier-use/#scope">this or
-                                other OSCAL instances</a>. This UUID should be assigned <a
-                                href="/concepts/identifier-use/#consistency">per-subject</a>, which
-                            means it should be consistently used to identify the same subject across
-                            revisions of the document.</p>
+                        <p>A <a href="/concepts/identifier-use/#machine-oriented" >machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance" >cross-instance</a> scope that can be used to reference this defined resource elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</p>
                     </remarks>
                     <!-- identifier declaration -->
                 </define-flag>
@@ -769,13 +753,8 @@
             <description>A textual label that provides a sub-type or characterization of the
                 property's <code>name</code>.</description>
             <remarks>
-                <p>This can be used to further distinguish or discriminate between the semantics of
-                    multiple properties of the same object with the same <code>name</code> and
-                        <code>ns</code>, or to group properties into categories.</p>
-                <p>A <code>class</code> can be used in validation rules to express extra constraints
-                    over named items of a specific <code>class</code> value. It is available for
-                    grouping, but unlike <code>group</code> is not expected specifically to
-                    designate any group membership as such.</p>
+                <p>This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same <code>name</code> and <code>ns</code>, or to group properties into categories.</p>
+                <p>A <code>class</code> can be used in validation rules to express extra constraints over named items of a specific <code>class</code> value. It is available for grouping, but unlike <code>group</code> is not expected specifically to designate any group membership as such.</p>
             </remarks>
         </define-flag>
         <define-flag name="group" as-type="token">
@@ -1132,17 +1111,10 @@
             </remarks>
         </define-flag>
         <remarks>
-            <p>A document identifier provides a <a href="/concepts/identifier-use/#globally-unique"
-                    >globally unique</a> identifier with a <a
-                    href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that is
-                used for a group of documents that are to be treated as different versions,
-                representations or digital surrogates of the same document.</p>
+            <p>A document identifier provides a <a href="/concepts/identifier-use/#globally-unique" >globally unique</a> identifier with a <a href="/concepts/identifier-use/#cross-instance">cross-instance</a> scope that is used for a group of documents that are to be treated as different versions, representations or digital surrogates of the same document.</p>
             <p>A document identifier provides an additional data point for identifying a document that can be assigned by a publisher or organization for purposes in a wider system, such as a digital object identifier (DOI) or a local content management system identifier.</p>
             <p>Use of a document identifier allows for document creators to associate sets of documents that are related in some way by the same <code>document-id</code>.</p>
-            <p>An OSCAL document always has an implicit document identifier provided by the
-                document's UUID, defined by the <code>uuid</code> on the top-level object. Having a
-                default UUID-based identifier ensures all documents can be minimally identified when
-                other document identifiers are not provided.</p>
+            <p>An OSCAL document always has an implicit document identifier provided by the document's UUID, defined by the <code>uuid</code> on the top-level object. Having a default UUID-based identifier ensures all documents can be minimally identified when other document identifiers are not provided.</p>
         </remarks>
     </define-field>
 </METASCHEMA>

--- a/src/metaschema/oscal_metadata_metaschema.xml
+++ b/src/metaschema/oscal_metadata_metaschema.xml
@@ -163,20 +163,6 @@
                 <define-flag name="uuid" as-type="uuid" required="yes">
                     <formal-name>Location Universally Unique Identifier</formal-name>
                     <description>A unique ID for the location, for reference.</description>
-                    <remarks>
-                        <p>A <a href="/concepts/identifier-use/#machine-oriented"
-                                >machine-oriented</a>, <a
-                                href="/concepts/identifier-use/#globally-unique">globally unique</a>
-                            identifier with <a href="/concepts/identifier-use/#cross-instance"
-                                >cross-instance</a> scope that can be used to reference this defined
-                            location elsewhere in <a href="/concepts/identifier-use/#scope">this or
-                                other OSCAL instances</a>. The locally defined <em>UUID</em> of the
-                                <code>location</code> can be used to reference the data item locally
-                            or globally (e.g., from an importing OSCAL instance). This UUID should
-                            be assigned <a href="/concepts/identifier-use/#consistency"
-                                >per-subject</a>, which means it should be consistently used to
-                            identify the same subject across revisions of the document.</p>
-                    </remarks>
                 </define-flag>
                 <model>
                     <define-field name="title" as-type="markup-line">
@@ -515,11 +501,7 @@
                 <group-as name="resources" in-json="ARRAY"/>
                 <define-flag name="uuid" as-type="uuid" required="yes">
                     <formal-name>Resource Universally Unique Identifier</formal-name>
-                    <description>A unique identifier for a resource, for referencing across document
-                        and trans-document scope.</description>
-                    <remarks>
-                        <p>A <a href="/concepts/identifier-use/#machine-oriented" >machine-oriented</a>, <a href="/concepts/identifier-use/#globally-unique">globally unique</a> identifier with <a href="/concepts/identifier-use/#cross-instance" >cross-instance</a> scope that can be used to reference this defined resource elsewhere in <a href="/concepts/identifier-use/#scope">this or other OSCAL instances</a>. This UUID should be assigned <a href="/concepts/identifier-use/#consistency">per-subject</a>, which means it should be consistently used to identify the same subject across revisions of the document.</p>
-                    </remarks>
+                    <description>A unique identifier for a resource.</description>
                     <!-- identifier declaration -->
                 </define-flag>
                 <model>
@@ -722,19 +704,7 @@
         <define-flag name="uuid" as-type="uuid">
             <formal-name>Property Universally Unique Identifier</formal-name>
             <!-- identifier declaration -->
-            <description>A unique identifier for a property, for referencing across trans-document
-                scope.</description>
-            <remarks>
-                <p>A <a href="/concepts/identifier-use/#machine-oriented">machine-oriented</a>, <a
-                        href="/concepts/identifier-use/#globally-unique">globally unique</a>
-                    identifier with <a href="/concepts/identifier-use/#cross-instance"
-                        >cross-instance</a> scope that can be used to reference this defined
-                    property elsewhere in <a href="/concepts/identifier-use/#scope">this or other
-                        OSCAL instances</a>. This UUID should be assigned <a
-                        href="/concepts/identifier-use/#consistency">per-subject</a>, which means it
-                    should be consistently used to identify the same subject across revisions of the
-                    document.</p>
-            </remarks>
+            <description>A unique identifier for a property.</description>
         </define-flag>
         <define-flag name="ns" as-type="uri" default="http://csrc.nist.gov/ns/oscal">
             <formal-name>Property Namespace</formal-name>

--- a/src/metaschema/oscal_profile_metaschema.xml
+++ b/src/metaschema/oscal_profile_metaschema.xml
@@ -5,17 +5,27 @@
 ]>
 <?xml-stylesheet type="text/css" href="metaschema-author.css"?>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0" xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../build/metaschema/toolchains/xslt-M4/validate/metaschema.xsd">
+      xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
       <schema-name>OSCAL Profile Model</schema-name>
       <schema-version>1.0.4</schema-version>
       <short-name>oscal-profile</short-name>
       <namespace>http://csrc.nist.gov/ns/oscal/1.0</namespace>
       <json-base-uri>http://csrc.nist.gov/ns/oscal</json-base-uri>
       <remarks>
-            <p>In OSCAL a <a href="https://pages.nist.gov/OSCAL/concepts/layer/control/profile/">profile</a> represents a <a href="https://pages.nist.gov/OSCAL/concepts/terminology/#baseline">baseline</a> of selected <a href="https://pages.nist.gov/OSCAL/concepts/terminology/#control">controls</a> from one or more control catalogs. An OSCAL profile is used in an OSCAL <a href="https://pages.nist.gov/OSCAL/concepts/layer/implementation/ssp/">system security plan</a> (SSP) to determine the baseline of controls that must be implemented by the information system. The effective set of controls is generated through <a href="https://pages.nist.gov/OSCAL/concepts/processing/profile-resolution/">profile resolution</a> process.</p>
-            <p>In OSCAL a profile represents a set of selected controls from one or more control catalogs. Such a set of controls can be referenced by an OSCAL system security plan (SSP) to establish a control baseline. This effective set of controls is produced from an OSCAL profile using a deterministic, predictable process called profile resolution.</p>
+            <p>In OSCAL a profile represents a set of selected <a
+                        href="https://pages.nist.gov/OSCAL/concepts/terminology/#control"
+                        >controls</a> from one or more control catalogs. Such a set of controls can
+                  be referenced by an OSCAL <a
+                        href="https://pages.nist.gov/OSCAL/concepts/layer/implementation/ssp/"
+                        >system security plan</a> (SSP) to establish a control <a
+                        href="https://pages.nist.gov/OSCAL/concepts/terminology/#baseline"
+                        >baseline</a>. This effective set of controls is produced from an OSCAL
+                  profile using a deterministic, predictable process called <a
+                        href="https://pages.nist.gov/OSCAL/concepts/processing/profile-resolution/"
+                        >profile resolution</a>.</p>
             <p>A profile references one or more OSCAL catalogs or profiles to import controls for control selection and tailoring. A profile can also describe how a resulting catalog is structured. When the profile is resolved, these selections and modifications are processed to produce a resulting OSCAL catalog.</p>
-            <p>OSCAL profiles have uses beyond establishing a baseline, such as documentation generation or as reference tables for validations.</p>
+            <p>OSCAL profiles have uses beyond establishing control baselines, such as documentation
+                  generation or as reference tables for validations.</p>
       </remarks>
 
       <import href="oscal_metadata_metaschema.xml"/>
@@ -23,7 +33,8 @@
 
       <define-assembly name="profile">
             <formal-name>Profile</formal-name>
-            <description>Each OSCAL profile is defined by a <code>profile</code> element</description>
+            <description>Each OSCAL profile is defined by a <code>profile</code>
+                  element.</description>
             <root-name>profile</root-name>
             <define-flag name="uuid" as-type="uuid" required="yes">
                   <formal-name>Profile Universally Unique Identifier</formal-name>
@@ -104,11 +115,15 @@
                         <description>A Combine element defines how to resolve duplicate instances of the same control (e.g., controls with the same ID).</description>
                         <define-flag name="method" as-type="string">
                               <formal-name>Combination Method</formal-name>
-                              <description>Declare how clashing controls should be handled</description>
+                              <description>Declare how clashing controls should be
+                                    handled.</description>
                               <constraint>
                                     <allowed-values>
                                           <enum value="use-first">Use the first definition - the first control with a given ID is used; subsequent ones are discarded</enum>
-                                          <enum value="merge" deprecated="1.0.1">**(deprecated)** **(unspecified)** Merge - controls with the same ID are combined</enum>
+                                          <enum value="merge" deprecated="1.0.1"
+                                                  >**(<i>deprecated</i>)** **(<i>unspecified</i>)**
+                                                Merge - controls with the same ID are
+                                                combined</enum>
                                           <enum value="keep">Keep - controls with the same ID are kept, retaining the clash</enum>
                                     </allowed-values>
                               </constraint>
@@ -146,17 +161,20 @@
       </define-assembly>
       <define-assembly name="group">
             <formal-name>Control Group</formal-name>
-            <description>A group of (selected) controls or of groups of controls</description>
+            <description>A group of (selected) controls or of groups of controls.</description>
             <define-flag name="id" as-type="token">
-                  <!-- This is an id because the idenfier is assigned and managed externally by humans. -->
+                  <!-- This is an id because the identifier is assigned and managed externally by humans. -->
                   <formal-name>Group Identifier</formal-name>
                   <!-- Identifier Declaration -->
-                  <description>Provides locally unique means to identify a given control group.</description>
+                  <description>Identifies the group.</description>
                   <prop name="value-type" value="identifier"/>
                   <prop name="identifier-type" value="human-oriented"/>
                   <prop name="identifier-uniqueness" value="instance"/>
                   <prop name="identifier-scope" value="cross-instance"/>
                   <prop name="identifier-persistence" value="per-subject"/>
+                  <remarks>
+                       <p>This optional data element is available to support hyperlinking to formal groups or families as defined in control catalogs, among other operations.</p>
+                  </remarks>
             </define-flag>
             <define-flag name="class" as-type="token">
                   <formal-name>Group Class</formal-name>
@@ -198,17 +216,18 @@
       </define-assembly>
       <define-assembly name="modify">
             <formal-name>Modify Controls</formal-name>
-            <description>Set parameters or amend controls in resolution</description>
+            <description>Set parameters or amend controls in resolution.</description>
             <model>
                   <define-assembly name="set-parameter" max-occurs="unbounded">
                         <formal-name>Parameter Setting</formal-name>
-                        <description>A parameter setting, to be propagated to points of insertion</description>
+                        <description>A parameter setting, to be propagated to points of
+                              insertion.</description>
                         <group-as name="set-parameters" in-json="ARRAY"/>
                         <define-flag required="yes" name="param-id" as-type="token">
                               <!-- This is an id because the idenfier is assigned and managed by humans. -->
                               <formal-name>Parameter ID</formal-name>
                               <!-- Identifier Declaration -->
-                              <description>Provides locally unique means to identify a given paramater.</description>
+                              <description>An identifier for the parameter.</description>
                               <prop name="value-type" value="identifier"/>
                               <prop name="identifier-type" value="human-oriented"/>
                               <prop name="identifier-uniqueness" value="instance"/>
@@ -242,7 +261,8 @@
                               </define-field>
                               <define-field name="usage" as-type="markup-multiline" in-xml="WITH_WRAPPER">
                                     <formal-name>Parameter Usage Description</formal-name>
-                                    <description>Describes the purpose and use of a parameter</description>
+                                    <description>Describes the purpose and use of a
+                                          parameter.</description>
                               </define-field>
                               <assembly ref="parameter-constraint" max-occurs="unbounded">
                                     <use-name>constraint</use-name>
@@ -278,7 +298,8 @@
                                     <group-as name="removes" in-json="ARRAY"/>
                                     <define-flag name="by-name" as-type="token">
                                           <formal-name>Reference by (assigned) name</formal-name>
-                                          <description>Identify items to remove by matching their assigned name</description>
+                                          <description>Identify items remove by matching their
+                                                assigned name.</description>
                                     </define-flag>
                                     <define-flag name="by-class" as-type="token">
                                           <formal-name>Reference by class</formal-name>
@@ -290,7 +311,10 @@
                                     </define-flag>
                                     <define-flag name="by-item-name" as-type="token">
                                           <formal-name>Item Name Reference</formal-name>
-                                          <description>Identify items to remove by the name of the item's information element name, e.g. <code>title</code> or <code>prop</code></description>
+                                          <description>Identify items to remove by the name of the
+                                                item's information object name, e.g.
+                                                  <code>title</code> or
+                                                <code>prop</code>.</description>
                                           <constraint>
                                                 <allowed-values>
                                                       <enum value="param">A descendant parameter and all of its descendants.</enum>
@@ -313,11 +337,14 @@
                               </define-assembly>
                               <define-assembly name="add" max-occurs="unbounded">
                                     <formal-name>Addition</formal-name>
-                                    <description>Specifies contents to be added into controls, in resolution</description>
+                                    <description>Specifies contents to be added into controls, in
+                                          resolution.</description>
                                     <group-as name="adds" in-json="ARRAY"/>
                                     <define-flag name="position" as-type="token" default="ending">
                                           <formal-name>Position</formal-name>
-                                          <description>Where to add the new content with respect to the targeted element (beside it or inside it)</description>
+                                          <description>Where to add the new content with respect to
+                                                the targeted element (beside it or inside
+                                                it).</description>
                                           <constraint>
                                                 <allowed-values>
                                                       <enum value="before">Preceding the by-id target</enum>
@@ -414,22 +441,22 @@
       </define-assembly>
       <define-assembly name="select-control-by-id" scope="local">
             <formal-name>Select Control</formal-name>
-            <description>Select a control or controls from an imported control set</description>
+            <description>Select a control or controls from an imported control set.</description>
             <flag ref="with-child-controls"/>
             <model>
                   <define-field name="with-id" as-type="token" max-occurs="unbounded">
                         <formal-name>Match Controls by Identifier</formal-name>
-                        <description></description>
+                        <description>Selecting a control by its ID given as a literal.</description>
                         <group-as name="with-ids" in-json="ARRAY"/>
                   </define-field>
                   <define-assembly name="matching" max-occurs="unbounded">
                         <formal-name>Match Controls by Pattern</formal-name>
-                        <description>Select controls by (regular expression) match on ID</description>
+                        <description>Selecting a set of controls by matching their IDs with a
+                              wildcard pattern.</description>
                         <group-as name="matching" in-json="ARRAY"/>
                         <flag ref="pattern"/>
                   </define-assembly>
             </model>
-            <!--The following doesn't apply when this object definition is used for excluding not including controls-->
             <remarks>
                   <p>If <code>with-child-controls</code> is <q>yes</q> on the call to a control, no sibling <code>call</code>elements need to be used to call any controls appearing within it. Since generally, this is how control enhancements are represented (as controls within controls), this provides a way to include controls with all their dependent controls (enhancements) without having to call them individually.</p>
             </remarks>


### PR DESCRIPTION
# Committer Notes

Suggested final / polishing edits to `description` and `remarks` in metaschemas: `catalog`, `profile`, `control-common` and `metadata`.

The changes include shortening descriptions I thought to be too long for tooltips, and extending their remarks of the flag, field or assembly, instead. There are plenty of other cosmetic changes including adding periods to any descriptions that did not have them.

Also enhanced CSS for authoring.

Happy to clean up further, e.g. addressing whitespace.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
